### PR TITLE
Add example.cookies.json file

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
 name: Test and lint
 
 on:
+  workflow_dispatch:
   pull_request:
     types:
       - opened

--- a/example.cookies.json
+++ b/example.cookies.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "ORGANIC_SESSION",
+    "value": "1",
+    "domain": ".www.storyblocks.com",
+    "path": "/video/stock",
+    "expires": -1,
+    "httpOnly": false,
+    "secure": false
+  },
+  {
+    "name": "ORGANIC_SESSION",
+    "value": "1",
+    "domain": ".www.storyblocks.com",
+    "path": "/",
+    "expires": -1,
+    "httpOnly": false,
+    "secure": false
+  }
+]


### PR DESCRIPTION
This pull request adds a new example.cookies.json file to the repository. 

Note: The example.cookies.json file DOES NOT have all necessary cookies and serves only as an example. It CANNOT be used in production.